### PR TITLE
Fix a typo.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -4936,7 +4936,7 @@ ARG can extend the bounds beyond the current defun."
        lispy-avy-style-paren))))
 
 (defun lispy-ace-symbol (arg)
-  "Jump to a symbol withing the current sexp and mark it.
+  "Jump to a symbol within the current sexp and mark it.
 Sexp is obtained by exiting the list ARG times."
   (interactive "p")
   (lispy--out-forward
@@ -5009,7 +5009,7 @@ Use STYLE function to update the overlays."
        (post #'avy--overlay-post)))))
 
 (defun lispy-ace-symbol-replace (arg)
-  "Jump to a symbol withing the current sexp and delete it.
+  "Jump to a symbol within the current sexp and delete it.
 Sexp is obtained by exiting the list ARG times."
   (interactive "p")
   (lispy-ace-symbol arg)


### PR DESCRIPTION
"withing" -> "within"